### PR TITLE
[quantizer & converter] support int16 quantization

### DIFF
--- a/tinynn/converter/base.py
+++ b/tinynn/converter/base.py
@@ -99,8 +99,14 @@ class TFLiteConverter(object):
                 )
         elif quantize_target_type == 'int8':
             self.q_type = np.int8
+        elif quantize_target_type == 'int16':
+            if self.hybrid:
+                raise AttributeError('Hybrid kernels supports int8 only')
+            if not self.strict_symmetric_check:
+                raise AttributeError('Int16 quantization requires strict_symmetric_check=True')
+            self.q_type = np.int16
         else:
-            raise AttributeError(f'unknown quantize_target_type: {quantize_target_type}, expected: uint8, int8')
+            raise AttributeError(f'unknown quantize_target_type: {quantize_target_type}, expected: uint8, int8, int16')
 
         if dump_config_path and not dump_jit_model_path:
             raise AssertionError("when dump_config_path is set, dump_jit_model_path is required to be set")

--- a/tinynn/converter/operators/torch/base.py
+++ b/tinynn/converter/operators/torch/base.py
@@ -512,7 +512,7 @@ class OperatorConverter(ABC):
         assert tensor.numel() == 1
         assert tensor.dtype == torch.float32
         if not tensor.is_nonzero():
-            if self.q_type == np.uint8:
+            if self.q_type in (np.uint8, np.int16):
                 return torch.quantize_per_tensor(tensor, 0.5, 128, torch.quint8)
             elif self.q_type == np.int8:
                 return torch.quantize_per_tensor(tensor, 0.5, 0, torch.qint8)
@@ -521,11 +521,15 @@ class OperatorConverter(ABC):
                 return torch.quantize_per_tensor(tensor, -tensor[0] / 127, 255, torch.quint8)
             elif self.q_type == np.int8:
                 return torch.quantize_per_tensor(tensor, -tensor[0] / 127, 0, torch.qint8)
+            elif self.q_type == np.int16:
+                return torch.quantize_per_tensor(tensor, -tensor[0] / 127, 128, torch.quint8)
         else:
             if self.q_type == np.uint8:
                 return torch.quantize_per_tensor(tensor, tensor[0] / 127, 0, torch.quint8)
             elif self.q_type == np.int8:
                 return torch.quantize_per_tensor(tensor, tensor[0] / 127, 0, torch.qint8)
+            elif self.q_type == np.int16:
+                return torch.quantize_per_tensor(tensor, tensor[0] / 127, 128, torch.quint8)
 
 
 def get_prop_from_node(node, prop, assert_type=None, return_type=False):

--- a/tinynn/converter/operators/torch/quantized.py
+++ b/tinynn/converter/operators/torch/quantized.py
@@ -96,8 +96,13 @@ class QuantizedConv2dOperator(QuantizedConv2dSchema):
                     bias = self.quantize(bias, bias_scale, bias_zero_point, dtype=torch.uint8)
                 elif self.q_type == np.int8:
                     bias = self.quantize(bias, bias_scale, bias_zero_point, dtype=torch.int8)
+                elif self.q_type == np.int16:
+                    bias = self.quantize(bias, bias_scale, bias_zero_point, dtype=torch.int16)
             else:
-                bias = self.quantize(bias, bias_scale, bias_zero_point, dtype=torch.int32, dim=bias_dim)
+                if self.q_type == np.int16:
+                    bias = self.quantize(bias, bias_scale, bias_zero_point, dtype=torch.int64, dim=bias_dim)
+                else:
+                    bias = self.quantize(bias, bias_scale, bias_zero_point, dtype=torch.int32, dim=bias_dim)
 
             bias_tensor = self.create_attr_tensor(bias)
             inputs.append(bias_tensor)
@@ -227,7 +232,10 @@ class QuantizedLinearOperator(QuantizedLinearSchema):
             bias = torch.zeros(out_features, dtype=torch.float)
 
         bias_scale = input_tensor.quantization.scale * weight_tensor.quantization.scale
-        bias = self.quantize(bias, bias_scale, 0, dtype=torch.int32)
+        if self.q_type == np.int16:
+            bias = self.quantize(bias, bias_scale, 0, dtype=torch.int64)
+        else:
+            bias = self.quantize(bias, bias_scale, 0, dtype=torch.int32)
         bias_tensor = self.create_attr_tensor(bias)
 
         inputs = [input_tensor, weight_tensor, bias_tensor]


### PR DESCRIPTION
Related issue: https://github.com/alibaba/TinyNeuralNetwork/issues/47

Example usage:
```py
import argparse
import os
import sys

CURRENT_PATH = os.path.abspath(os.path.dirname(__file__))

sys.path.insert(1, os.path.join(CURRENT_PATH, '../../'))

import torch
import torch.nn as nn
import torch.optim as optim

from examples.models.cifar10.mobilenet import DEFAULT_STATE_DICT, Mobilenet
from tinynn.converter import TFLiteConverter
from tinynn.graph.quantization.quantizer import QATQuantizer
from tinynn.graph.tracer import model_tracer
from tinynn.util.cifar10 import get_dataloader, train_one_epoch, validate
from tinynn.util.train_util import DLContext, get_device, train


def main_worker(args):
    with model_tracer():
        model = Mobilenet()
        model.load_state_dict(torch.load(DEFAULT_STATE_DICT))

        # Provide a viable input for the model
        dummy_input = torch.rand((1, 3, 224, 224))

        # TinyNeuralNetwork provides a QATQuantizer class that may rewrite the graph for and perform model fusion for
        # quantization. The model returned by the `quantize` function is ready for QAT.
        # By default, the rewritten model (in the format of a single file) will be generated in the working directory.
        # You may also pass some custom configuration items through the argument `config` in the following line. For
        # example, if you have a QAT-ready model (e.g models in torchvision.models.quantization),
        # then you may use the following line.
        #   quantizer = QATQuantizer(model, dummy_input, work_dir='out', config={'rewrite_graph': False})
        # Alternatively, if you have modified the generated model description file and want the quantizer to load it
        # instead, then use the code below.
        #     quantizer = QATQuantizer(
        #         model, dummy_input, work_dir='out', config={'force_overwrite': False, 'is_input_quantized': None}
        #     )
        # The `is_input_quantized` in the previous line is a flag on the input tensors whether they are quantized or
        # not, which can be None (False for all inputs) or a list of booleans that corresponds to the inputs.
        # Also, we support multiple qschemes for quantization preparation. There are several common choices.
        #   a. Asymmetric uint8. (default) config={'asymmetric': True, 'per_tensor': True}
        #      The is the most common choice and also conforms to the legacy TFLite quantization spec.
        #   b. Asymmetric int8. config={'asymmetric': True, 'per_tensor': False}
        #      The conforms to the new TFLite quantization spec. In legacy TF versions, this is usually used in post
        #      quantization. Compared with (a), it has support for per-channel quantization in supported kernels
        #      (e.g Conv), while (a) does not.
        #   c. Symmetric int8. config={'asymmetric': False, 'per_tensor': False}
        #      The is same to (b) with no offsets, which may be used on some low-end embedded chips.
        #   d. Symmetric uint8. config={'asymmetric': False, 'per_tensor': True}
        #      The is same to (a) with no offsets. But it is rarely used, which just serves as a placeholder here.

        quantizer = QATQuantizer(model, dummy_input, work_dir='out', config={'asymmetric': False, 'per_tensor': False})
        qat_model = quantizer.quantize()
        quantizer.rescale_activations_with_quant_min_max(0, 65535)

    print(qat_model)

    # Use DataParallel to speed up training when possible
    if torch.cuda.device_count() > 1:
        qat_model = nn.DataParallel(qat_model)

    # Move model to the appropriate device
    device = get_device()
    qat_model.to(device=device)

    context = DLContext()
    context.device = device
    context.train_loader, context.val_loader = get_dataloader(args.data_path, 224, args.batch_size, args.workers)
    context.max_epoch = 1
    context.criterion = nn.BCEWithLogitsLoss()
    context.optimizer = torch.optim.SGD(qat_model.parameters(), 0.01, momentum=0.9, weight_decay=5e-4)
    context.scheduler = optim.lr_scheduler.CosineAnnealingLR(context.optimizer, T_max=context.max_epoch + 1, eta_min=0)

    # Quantization-aware training
    train(qat_model, context, train_one_epoch, validate, qat=True)

    quantizer.rescale_activations_with_quant_min_max(0, 255)

    print(qat_model)

    with torch.no_grad():
        qat_model.eval()
        qat_model.cpu()

        # The step below converts the model to an actual quantized model, which uses the quantized kernels.
        qat_model = torch.quantization.convert(qat_model)

        # When converting quantized models, please ensure the quantization backend is set.
        torch.backends.quantized.engine = quantizer.backend

        # The code section below is used to convert the model to the TFLite format
        # If you need a quantized model with a specific data type (e.g. int8)
        # you may specify `quantize_target_type='int8'` in the following line.
        # If you need a quantized model with strict symmetric quantization check (with pre-defined zero points),
        # you may specify `strict_symmetric_check=True` in the following line.
        # converter = TFLiteConverter(qat_model, dummy_input, tflite_path='out/qat_model.tflite')
        converter = TFLiteConverter(qat_model, dummy_input, tflite_path='out/qat_model.tflite', quantize_target_type='int16', strict_symmetric_check=True)
        converter.convert()


if __name__ == '__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('--data-path', metavar='DIR', default="/data/datasets/cifar10", help='path to dataset')
    parser.add_argument('--config', type=str, default=os.path.join(CURRENT_PATH, 'config.yml'))
    parser.add_argument('--workers', type=int, default=8)
    parser.add_argument('--batch-size', type=int, default=192)

    args = parser.parse_args()
    main_worker(args)


```