### PR TITLE
[converter&quantizer] multiple changes for clamp

### DIFF
--- a/tests/quantizer_test.py
+++ b/tests/quantizer_test.py
@@ -839,6 +839,41 @@ class QuantizerTester(unittest.TestCase):
 
         check_quantize_rewrite(model, inputs)
 
+    def test_conv_clamp_min(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(3, 3, 1)
+
+            def forward(self, x):
+                s = self.conv(x)
+                return torch.clamp_min(s, 0.0)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
+    def test_clamp_max(self):
+        class Model(nn.Module):
+            def forward(self, x):
+                return torch.clamp_max(x, 1.0)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
+    def test_single_clamp(self):
+        class Model(nn.Module):
+            def forward(self, x):
+                return torch.clamp(x, -1.0, 1.0)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
     def test_conv1d(self):
         class Model(nn.Module):
             def __init__(self) -> None:

--- a/tests/quantizer_test.py
+++ b/tests/quantizer_test.py
@@ -874,6 +874,26 @@ class QuantizerTester(unittest.TestCase):
 
         check_quantize_rewrite(model, inputs)
 
+    def test_single_clamp_min_only(self):
+        class Model(nn.Module):
+            def forward(self, x):
+                return torch.clamp(x, -1.0)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
+    def test_single_clamp_max_only(self):
+        class Model(nn.Module):
+            def forward(self, x):
+                return torch.clamp(x, None, -1.0)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
     def test_conv1d(self):
         class Model(nn.Module):
             def __init__(self) -> None:

--- a/tinynn/converter/operators/torch/aten.py
+++ b/tinynn/converter/operators/torch/aten.py
@@ -1473,7 +1473,7 @@ class ATenClampOperator(ATenClampSchema):
                         quantization=input_tensor.quantization,
                     )
                 else:
-                    max_value_tensor = self.create_attr_tensor(max_value_tensor)
+                    max_value_tensor = self.create_attr_tensor(max_value_arr)
             if has_min and has_max:
                 inter_tensor = self.create_transform_tensor(
                     np.minimum(input_tensor.tensor, min_value_tensor.tensor), quantization=input_tensor.quantization
@@ -1484,7 +1484,7 @@ class ATenClampOperator(ATenClampSchema):
                 ops.append(tfl.MinimumOperator([inter_tensor, max_value_tensor], outputs))
             elif has_min:
                 outputs = self.to_tfl_tensors(self.output_names, self.output_tensors)
-                ops.append(tfl.MaximumOperator([input_tensor, max_value_tensor], outputs))
+                ops.append(tfl.MaximumOperator([input_tensor, min_value_tensor], outputs))
             else:
                 outputs = self.to_tfl_tensors(self.output_names, self.output_tensors)
                 ops.append(tfl.MinimumOperator([input_tensor, max_value_tensor], outputs))

--- a/tinynn/graph/quantization/quantizer.py
+++ b/tinynn/graph/quantization/quantizer.py
@@ -1353,6 +1353,38 @@ class QATQuantizer(object):
                         # It is even simple here. We only need to swap the order of the tensors.
                         node.module.parse_args(node.prev_tensors[1], node.prev_tensors[0])
 
+        # Rewrite torch.clamp_{min,max} to torch.clamp
+        def _is_clamp_min_max_node(node: TraceNode, custom_data):
+            cur_module = node.module
+            cur_class = type(cur_module)
+            if cur_class == TraceFunction:
+                return cur_module.kind in ('clamp_min', 'clamp_max') and node.next_tensors[0].dtype == torch.float32
+
+        clamp_min_max_nodes = graph.filter_forward_nodes(_is_clamp_min_max_node)
+        log.info(f'rewriting clamp_{{min,max}} for {[node.unique_name for node in convertible_nodes]}')
+        for node in clamp_min_max_nodes:
+            kw = node.module.kind[-3:]
+            _parse_args = eval(f'lambda {kw}, *args, **kwargs: {kw}')
+
+            val = eval(f'_parse_args({node.module.args_string_no_self})')
+
+            if kw != 'min' or val != 0.0:
+                continue
+
+            if kw == 'min':
+                arg_str = f'{val}'
+            else:
+                arg_str = f'None, {val}'
+
+            sub_str = f'_{kw}'
+            node.module.kind = node.module.kind.replace(sub_str, '')
+            node.module.func_type = node.module.func_type.replace(sub_str, '')
+            node.module.full_name = '.'.join(node.module.full_name.split('.')[:-1] + [node.module.func_type])
+
+            node.module.args_template_no_self = arg_str
+            node.module.args_template = f'{{}}, {arg_str}'
+            node.module.update_args_string()
+
         # Rewrite torch.clamp to relu and relu6
         def _is_clamp_node(node: TraceNode, custom_data):
             cur_module = node.module
@@ -1390,7 +1422,7 @@ class QATQuantizer(object):
                 arg_str = ''
 
             node.module.args_template_no_self = arg_str
-            node.module.args_template = f'{{}} {arg_str}'
+            node.module.args_template = f'{{}}, {arg_str}'
             node.module.update_args_string()
 
         # Rewrite other fusable functions
@@ -1815,6 +1847,8 @@ class QATQuantizer(object):
                     'bmm',
                     'abs',
                     'sum',
+                    'clamp_min',
+                    'clamp_max',
                 )
             else:
                 if LooseVersion(torch.__version__) >= LooseVersion('1.13.0'):
@@ -1908,7 +1942,7 @@ class QATQuantizer(object):
         # Remove consecutive dequant quant nodes
         def _is_consecutive_dequant_quant_nodes(node, custom_data):
             cur_type = node.type()
-            skip_types = set(['bmm', 'matmul', 'truediv'])
+            skip_types = set(['bmm', 'matmul', 'truediv', 'clamp_min', 'clamp_max'])
             if self.set_quantizable_op_stats:
                 skip_types |= set(KNOWN_QSTATS.keys())
             skip_types_prev = skip_types | set(['reciprocal'])


### PR DESCRIPTION
1. [converter] Passthrough elementwise op pass for `MINIMUM` and `MAXIMUM`
2. [converter] Rewrite quantizable support for `MINIMUM` and `MAXIMUM`
3. [quantizer] Fix quantization rewrite for `torch.clamp_min`, `torch.clamp_max` and `torch.clamp`
4. [converter] Fix translation for `torch.clamp` with quantized input tensors