### PR TITLE
[converter] remove duplicate keys

### DIFF
--- a/tinynn/converter/operators/torch/__init__.py
+++ b/tinynn/converter/operators/torch/__init__.py
@@ -91,7 +91,6 @@ OPERATOR_CONVERTER_DICT: typing.Dict[str, OperatorConverter] = {
     "aten::flip": ATenFlipOperator,
     "aten::floor": ATenFloorOperator,
     "aten::floor_divide": ATenFloorDivideOperator,
-    "aten::leaky_relu": ATenLeakyReluOperator,
     "aten::matmul": ATenMatmulOperator,
     "aten::mm": ATenMmOperator,
     "aten::flatten": ATenFlattenOperator,


### PR DESCRIPTION
remove one of the duplicate keys since "aten::leaky_relu" is registered twice at line 29 and 94 in [`__init__.py`](https://github.com/alibaba/TinyNeuralNetwork/blob/89504ee5a0e1b353a710646e16affbd297f47e72/tinynn/converter/operators/torch/__init__.py#L29)