### PR TITLE
[tracer] inplace codegen & q_rewrite

### DIFF
--- a/tests/quantizer_test.py
+++ b/tests/quantizer_test.py
@@ -1260,7 +1260,6 @@ class QuantizerTester(unittest.TestCase):
                 self.conv = nn.Conv2d(3, 1, 1, 1)
 
             def forward(self, x):
-                # return self.conv(x) +
                 return x + torch.squeeze(self.conv.weight, 1).expand(1, 3, 224, 224)
 
         model = Model()
@@ -1275,7 +1274,6 @@ class QuantizerTester(unittest.TestCase):
                 self.conv = nn.Conv2d(3, 1, 1, 1)
 
             def forward(self, x):
-                # return self.conv(x) +
                 return x + self.conv.bias.view(-1, 1, 1).expand(1, 3, 224, 224)
 
         model = Model()

--- a/tests/quantizer_test.py
+++ b/tests/quantizer_test.py
@@ -24,7 +24,7 @@ def show_source(model, title, reload_cache=True):
     print(source)
 
 
-def check_quantize_rewrite(model, inputs, show_rewritten=True, skip_train=False):
+def check_quantize_rewrite(model, inputs, show_rewritten=True, skip_train=False, skip_trace=False):
     with model_tracer():
         config = {'remove_weights_after_load': True, 'ignore_layerwise_config': True}
         if sys.platform == 'win32':
@@ -48,7 +48,14 @@ def check_quantize_rewrite(model, inputs, show_rewritten=True, skip_train=False)
 
             qat_model = quantizer.convert(qat_model)
 
-            torch.jit.trace(qat_model, inputs)
+            # Evaluation on converted model doesn't fail
+            if isinstance(inputs, (list, tuple)):
+                qat_model(*inputs)
+            else:
+                qat_model(inputs)
+
+            if not skip_trace:
+                torch.jit.trace(qat_model, inputs)
 
 
 def check_dequantize_rewrite(model, inputs, show_rewritten=True, skip_train=False):
@@ -1240,6 +1247,125 @@ class QuantizerTester(unittest.TestCase):
         class Model(nn.Module):
             def forward(self, x):
                 return (x + x[:, 0:1]).relu()
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
+    def test_known_param_from_module_weight(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(3, 1, 1, 1)
+
+            def forward(self, x):
+                # return self.conv(x) +
+                return x + torch.squeeze(self.conv.weight, 1).expand(1, 3, 224, 224)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
+    def test_known_param_from_module_bias(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(3, 1, 1, 1)
+
+            def forward(self, x):
+                # return self.conv(x) +
+                return x + self.conv.bias.view(-1, 1, 1).expand(1, 3, 224, 224)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
+    def test_known_param_from_module_weight_qmod(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(3, 1, 1, 1)
+
+            def forward(self, x):
+                return self.conv(x).expand(1, 3, 224, 224) + torch.squeeze(self.conv.weight, 1).expand(1, 3, 224, 224)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs, skip_trace=True)
+
+    def test_known_param_from_module_weight_qmod_reverse(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(3, 1, 1, 1)
+
+            def forward(self, x):
+                return torch.squeeze(self.conv.weight, 1).expand(1, 3, 224, 224) + self.conv(x).expand(1, 3, 224, 224)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs, skip_trace=True)
+
+    def test_known_param_from_module_bias_qmod(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(3, 1, 1, 1)
+
+            def forward(self, x):
+                return self.conv(x).expand(1, 3, 224, 224) + self.conv.bias.view(-1, 1, 1).expand(1, 3, 224, 224)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs, skip_trace=True)
+
+    def test_known_param_from_module_bias_qmod_reverse(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(3, 1, 1, 1)
+
+            def forward(self, x):
+                return self.conv.bias.view(-1, 1, 1).expand(1, 3, 224, 224) + self.conv(x).expand(1, 3, 224, 224)
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs, skip_trace=True)
+
+    def test_known_param_simple(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.param = nn.Parameter(torch.randn(1, 3, 224, 224))
+
+            def forward(self, x):
+                return x * self.param
+
+        model = Model()
+        inputs = torch.randn(1, 3, 224, 224)
+
+        check_quantize_rewrite(model, inputs)
+
+    def test_known_param_submodule(self):
+        class SubModule(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.param = nn.Parameter(torch.randn(1, 3, 224, 224))
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.sub_module = SubModule()
+
+            def forward(self, x):
+                return x * self.sub_module.param
 
         model = Model()
         inputs = torch.randn(1, 3, 224, 224)

--- a/tinynn/graph/quantization/utils.py
+++ b/tinynn/graph/quantization/utils.py
@@ -21,3 +21,28 @@ def fuse_conv_bn_weights(conv_w, conv_b, bn_rm, bn_rv, bn_eps, bn_w, bn_b, trans
     return torch.nn.Parameter(fused_conv_w, conv_w.requires_grad), torch.nn.Parameter(
         fused_conv_b, conv_b.requires_grad
     )
+
+
+def get_parameter(mod: torch.nn.Module, param: str) -> torch.nn.Parameter:
+    # import pdb
+    # pdb.set_trace()
+    if param == 'weight':
+        if isinstance(mod, torch.nn.Sequential):
+            return getattr(mod[0], param)
+        elif hasattr(mod, 'weight_fake_quant'):
+            return mod.weight_fake_quant(getattr(mod, param))
+        elif hasattr(mod, 'set_weight_bias'):
+            return getattr(mod, param)()
+        else:
+            return getattr(mod, param)
+    elif param == 'bias':
+        if isinstance(mod, torch.nn.Sequential):
+            return getattr(mod[0], param)
+        elif hasattr(mod, 'weight_fake_quant'):
+            return getattr(mod, param)
+        elif hasattr(mod, 'set_weight_bias'):
+            return getattr(mod, param)()
+        else:
+            return getattr(mod, param)
+    else:
+        return getattr(mod, param)

--- a/tinynn/graph/tracer.py
+++ b/tinynn/graph/tracer.py
@@ -2300,13 +2300,15 @@ class TraceGraph(object):
         else:
             return True
 
-    def inplace_commit(self):
+    def inplace_commit(self, show_code: bool = False):
+        """Commit the changes to the TraceGraph and applies it to the model"""
         forward_block = self.__gen_forward_code(True)
         import_block = self.__gen_import_code()
 
         code = re.sub(r'^    ', '', forward_block, flags=re.MULTILINE)
 
-        log.info(f'The new forward function for the model:\n{code}')
+        if show_code:
+            log.info(f'The new forward function for the model:\n{code}')
 
         tmp_ns = {}
         exec(import_block, tmp_ns)

--- a/tinynn/graph/tracer.py
+++ b/tinynn/graph/tracer.py
@@ -290,7 +290,10 @@ class TraceNode(object):
                 and type(self.module) == TraceFunction
                 and self.module.is_property
             ):
-                ns = 'self.'
+                prev_t_ids = set(id(t) for t in self.prev_tensors)
+                next_t_ids = set(id(t) for t in self.prev_nodes[idx].next_tensors)
+                if len(prev_t_ids & next_t_ids) == 0:
+                    ns = 'self.'
             if node_idx is None:
                 return f'{ns}{node_name}'
             else:


### PR DESCRIPTION
## Features
1. `inplace_commit` for `TraceGraph`
2. `inplace=True` for `QATQuantizer` and its derivatives
3. Better naming for the params and buffers
4. The direct children (params & buffers) of the modules are now tracked

## Bugfixes
1. Avoid cloning a module (including its definition, code path and weights) if it's used more than once
2. Fix `update_submodule_in_node` for complicated namespaces