### PR TITLE
[Converter] Support GRU operator conversion with separated_rnn_gate_calc=False

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -225,7 +225,7 @@ You may also try out static quantization for LSTMs when you have PyTorch 1.13+. 
 #### What if my model runs slower when dynamic quantization is enabled?
 Please refer to [dynamic_with_selection.py](../examples/converter/dynamic_with_selection.py) for selective dynamic quantization.
 
-#### I need LSTMs with separated gate calculation when `unroll_rnn=True`.
+#### I need LSTM/GRUs with separated gate calculation when `unroll_rnn=True`.
 Please set `separated_rnn_gate_calc=True`.
 
 #### How to add state inputs and outputs for LSTMs/GRUs/RNNs with `unroll_rnn=True`?

--- a/docs/FAQ_zh-CN.md
+++ b/docs/FAQ_zh-CN.md
@@ -225,7 +225,7 @@ Note: 这些状态变量都是二维的，维度为`[batch_size, hidden_size或�
 #### 我的模型开了动态量化变得更慢了？
 请参考 [dynamic_with_selection.py](../examples/converter/dynamic_with_selection.py) 选择性的开启动态量化。
 
-#### 在设置了`unroll_rnn=True`后，LSTM中多个门的计算被融合了。有没有办法分开？
+#### 在设置了`unroll_rnn=True`后，LSTM/GRU中多个门的计算被融合了。有没有办法分开？
 尝试设置`separated_rnn_gate_calc=True`。
 
 #### 在`unroll_rnn=True`的情况下，怎么为包含LSTM、RNN和GRU的网络添加状态输入输出?

--- a/tests/converter_op_test.py
+++ b/tests/converter_op_test.py
@@ -4520,6 +4520,11 @@ class ConverterOPTester(unittest.TestCase):
         "torch.Tensor.scatter_ cannot take scalar inputs",
     )
     @unittest.skipIf(
+        LooseVersion(torch.__version__) >= LooseVersion('1.7.0')
+        and LooseVersion(torch.__version__) < LooseVersion('1.8.0'),
+        "torch.Tensor.scatter_ with scalar inputs fails",
+    )
+    @unittest.skipIf(
         LooseVersion(torch.__version__) >= LooseVersion('1.12.0')
         and LooseVersion(torch.__version__) < LooseVersion('1.13.0'),
         "https://github.com/pytorch/pytorch/issues/80508",
@@ -4543,6 +4548,11 @@ class ConverterOPTester(unittest.TestCase):
     @unittest.skipIf(
         LooseVersion(torch.__version__) < LooseVersion('1.7.0'),
         "torch.Tensor.scatter_ cannot take scalar inputs",
+    )
+    @unittest.skipIf(
+        LooseVersion(torch.__version__) >= LooseVersion('1.7.0')
+        and LooseVersion(torch.__version__) < LooseVersion('1.8.0'),
+        "torch.Tensor.scatter_ with scalar inputs fails",
     )
     @unittest.skipIf(
         LooseVersion(torch.__version__) >= LooseVersion('1.12.0')

--- a/tests/converter_op_test.py
+++ b/tests/converter_op_test.py
@@ -2951,6 +2951,30 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
+    
+    def test_gru_unroll_unseparated(self):
+        dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.gru = nn.GRU(10, 20)
+
+            def forward(self, x):
+                return self.gru(x)[0]
+
+        model = Model()
+        model.eval()
+
+        model_path = get_model_path()
+        converter = TFLiteConverter(
+            model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=False
+        )
+        converter.convert()
+
+        dummy_output = model(dummy_input)
+        tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
+        assert_close(dummy_output, tfl_output)
 
     def test_gru_batch_first_unroll_separated(self):
         dummy_input = torch.randn(1, 9, 10, dtype=torch.float32)
@@ -2969,6 +2993,30 @@ class ConverterOPTester(unittest.TestCase):
         model_path = get_model_path()
         converter = TFLiteConverter(
             model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=True
+        )
+        converter.convert()
+
+        dummy_output = model(dummy_input)
+        tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
+        assert_close(dummy_output, tfl_output, check_stride=False)
+    
+    def test_gru_batch_first_unroll_unseparated(self):
+        dummy_input = torch.randn(1, 9, 10, dtype=torch.float32)
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.gru = nn.GRU(10, 20, batch_first=True)
+
+            def forward(self, x):
+                return self.gru(x)[0]
+
+        model = Model()
+        model.eval()
+
+        model_path = get_model_path()
+        converter = TFLiteConverter(
+            model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=False
         )
         converter.convert()
 
@@ -3003,6 +3051,34 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(*dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
+    
+    def test_gru_with_state_tensor_unroll_unseparated(self):
+        dummy_input = [
+            torch.randn(9, 1, 10, dtype=torch.float32),
+            torch.randn(1, 1, 20, dtype=torch.float32),
+        ]
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.gru = nn.GRU(10, 20)
+
+            def forward(self, x, hx):
+                gru, hx = self.gru(x, hx)
+                return gru, hx
+
+        model = Model()
+        model.eval()
+
+        model_path = get_model_path()
+        converter = TFLiteConverter(
+            model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=False
+        )
+        converter.convert()
+
+        dummy_output = model(*dummy_input)
+        tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
+        assert_close(dummy_output, tfl_output)
 
     def test_gru_multi_layer_unroll_separated(self):
         dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
@@ -3021,6 +3097,30 @@ class ConverterOPTester(unittest.TestCase):
         model_path = get_model_path()
         converter = TFLiteConverter(
             model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=True
+        )
+        converter.convert()
+
+        dummy_output = model(dummy_input)
+        tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
+        assert_close(dummy_output, tfl_output)
+    
+    def test_gru_multi_layer_unroll_unseparated(self):
+        dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.gru = nn.GRU(10, 20, 2)
+
+            def forward(self, x):
+                return self.gru(x)[0]
+
+        model = Model()
+        model.eval()
+
+        model_path = get_model_path()
+        converter = TFLiteConverter(
+            model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=False
         )
         converter.convert()
 
@@ -3049,6 +3149,34 @@ class ConverterOPTester(unittest.TestCase):
         model_path = get_model_path()
         converter = TFLiteConverter(
             model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=True
+        )
+        converter.convert()
+
+        dummy_output = model(*dummy_input)
+        tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
+        assert_close(dummy_output, tfl_output)
+    
+    def test_gru_multi_layer_with_state_tensor_unroll_separated(self):
+        dummy_input = [
+            torch.randn(9, 1, 10, dtype=torch.float32),
+            torch.randn(2, 1, 20, dtype=torch.float32),
+        ]
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.gru = nn.GRU(10, 20, 2)
+
+            def forward(self, x, hx):
+                gru, hx = self.gru(x, hx)
+                return gru, hx
+
+        model = Model()
+        model.eval()
+
+        model_path = get_model_path()
+        converter = TFLiteConverter(
+            model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=False
         )
         converter.convert()
 
@@ -3277,6 +3405,30 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
+    
+    def test_bigru_unroll_unseparated(self):
+        dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.gru = nn.GRU(10, 20, bidirectional=True)
+
+            def forward(self, x):
+                return self.gru(x)[0]
+
+        model = Model()
+        model.eval()
+
+        model_path = get_model_path()
+        converter = TFLiteConverter(
+            model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=False
+        )
+        converter.convert()
+
+        dummy_output = model(dummy_input)
+        tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
+        assert_close(dummy_output, tfl_output)
 
     def test_bigru_multi_layer_unroll_separated(self):
         dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
@@ -3295,6 +3447,30 @@ class ConverterOPTester(unittest.TestCase):
         model_path = get_model_path()
         converter = TFLiteConverter(
             model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=True
+        )
+        converter.convert()
+
+        dummy_output = model(dummy_input)
+        tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
+        assert_close(dummy_output, tfl_output)
+    
+    def test_bigru_multi_layer_unroll_separated(self):
+        dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.gru = nn.GRU(10, 20, 2, bidirectional=True)
+
+            def forward(self, x):
+                return self.gru(x)[0]
+
+        model = Model()
+        model.eval()
+
+        model_path = get_model_path()
+        converter = TFLiteConverter(
+            model, dummy_input, model_path, nchw_transpose=False, unroll_rnn=True, separated_rnn_gate_calc=False
         )
         converter.convert()
 
@@ -4344,11 +4520,6 @@ class ConverterOPTester(unittest.TestCase):
         "torch.Tensor.scatter_ cannot take scalar inputs",
     )
     @unittest.skipIf(
-        LooseVersion(torch.__version__) >= LooseVersion('1.7.0')
-        and LooseVersion(torch.__version__) < LooseVersion('1.8.0'),
-        "torch.Tensor.scatter_ with scalar inputs fails",
-    )
-    @unittest.skipIf(
         LooseVersion(torch.__version__) >= LooseVersion('1.12.0')
         and LooseVersion(torch.__version__) < LooseVersion('1.13.0'),
         "https://github.com/pytorch/pytorch/issues/80508",
@@ -4372,11 +4543,6 @@ class ConverterOPTester(unittest.TestCase):
     @unittest.skipIf(
         LooseVersion(torch.__version__) < LooseVersion('1.7.0'),
         "torch.Tensor.scatter_ cannot take scalar inputs",
-    )
-    @unittest.skipIf(
-        LooseVersion(torch.__version__) >= LooseVersion('1.7.0')
-        and LooseVersion(torch.__version__) < LooseVersion('1.8.0'),
-        "torch.Tensor.scatter_ with scalar inputs fails",
     )
     @unittest.skipIf(
         LooseVersion(torch.__version__) >= LooseVersion('1.12.0')

--- a/tests/converter_op_test.py
+++ b/tests/converter_op_test.py
@@ -2951,7 +2951,7 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
-    
+
     def test_gru_unroll_unseparated(self):
         dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
 
@@ -2999,7 +2999,7 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output, check_stride=False)
-    
+
     def test_gru_batch_first_unroll_unseparated(self):
         dummy_input = torch.randn(1, 9, 10, dtype=torch.float32)
 
@@ -3051,7 +3051,7 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(*dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
-    
+
     def test_gru_with_state_tensor_unroll_unseparated(self):
         dummy_input = [
             torch.randn(9, 1, 10, dtype=torch.float32),
@@ -3103,7 +3103,7 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
-    
+
     def test_gru_multi_layer_unroll_unseparated(self):
         dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
 
@@ -3155,8 +3155,8 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(*dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
-    
-    def test_gru_multi_layer_with_state_tensor_unroll_separated(self):
+
+    def test_gru_multi_layer_with_state_tensor_unroll_unseparated(self):
         dummy_input = [
             torch.randn(9, 1, 10, dtype=torch.float32),
             torch.randn(2, 1, 20, dtype=torch.float32),
@@ -3405,7 +3405,7 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
-    
+
     def test_bigru_unroll_unseparated(self):
         dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
 
@@ -3453,8 +3453,8 @@ class ConverterOPTester(unittest.TestCase):
         dummy_output = model(dummy_input)
         tfl_output = tfl_run_model(model_path, dummy_input, dummy_output)
         assert_close(dummy_output, tfl_output)
-    
-    def test_bigru_multi_layer_unroll_separated(self):
+
+    def test_bigru_multi_layer_unroll_unseparated(self):
         dummy_input = torch.randn(9, 1, 10, dtype=torch.float32)
 
         class Model(nn.Module):

--- a/tinynn/converter/operators/torch/aten.py
+++ b/tinynn/converter/operators/torch/aten.py
@@ -706,7 +706,7 @@ class ATenGruOperator(ATenGruSchema):
                             )                            
                             
                             ops.append(tfl.FullyConnectedOperator([t, w_i, b_i], [input_mm]))                            
-                            ops.append(tfl.FullyConnectedOperator([t, w_h, b_h], [hidden_mm]))
+                            ops.append(tfl.FullyConnectedOperator([h, w_h, b_h], [hidden_mm]))
 
                             left_in = np.split(input_mm.tensor, 3, axis=1)
                             dim_tensor = self.create_attr_tensor(np.array([1], dtype='int32'))

--- a/tinynn/converter/operators/torch/aten.py
+++ b/tinynn/converter/operators/torch/aten.py
@@ -554,8 +554,7 @@ class ATenGruOperator(ATenGruSchema):
     ):
         assert is_train in (False, 0)
         self.unroll_rnn = True
-        self.separated_rnn_gate_calc = False
-
+        
         expected_num_params = 2 * num_layers
         params_step = 2
         if has_biases:

--- a/tinynn/converter/operators/torch/aten.py
+++ b/tinynn/converter/operators/torch/aten.py
@@ -554,7 +554,7 @@ class ATenGruOperator(ATenGruSchema):
     ):
         assert is_train in (False, 0)
         self.unroll_rnn = True
-        self.separated_rnn_gate_calc = True
+        self.separated_rnn_gate_calc = False
 
         expected_num_params = 2 * num_layers
         params_step = 2
@@ -685,73 +685,155 @@ class ATenGruOperator(ATenGruSchema):
                     for i, t in enumerate(input_ts[::stride]):
 
                         input_mm_list = []
-                        for j, (w_i, b_i) in enumerate(zip(w_i_list, b_i_list)):
+                        
+                        if not self.separated_rnn_gate_calc:
+                            
+                            wir, wiz, win = w_i_list
+                            whr, whz, whn = w_r_list
+                            bir, biz, bin = b_i_list
+                            bhr, bhz, bhn = b_r_list
+
+                            w_i = self.create_attr_tensor(np.concatenate([wir.tensor, wiz.tensor, win.tensor], 0))
+                            w_h = self.create_attr_tensor(np.concatenate([whr.tensor, whz.tensor, whn.tensor], 0))
+                            b_i = self.create_attr_tensor(np.concatenate([bir.tensor, biz.tensor, bin.tensor], 0))
+                            b_h = self.create_attr_tensor(np.concatenate([bhr.tensor, bhz.tensor, bhn.tensor], 0))
 
                             input_mm = self.create_transform_tensor(
                                 np.matmul(t.tensor, np.transpose(w_i.tensor, [1, 0])) + b_i.tensor
                             )
-                            ops.append(tfl.FullyConnectedOperator([t, w_i, b_i], [input_mm]))
-                            input_mm_list.append(input_mm)
+                            hidden_mm = self.create_transform_tensor(
+                                np.matmul(h.tensor, np.transpose(w_h.tensor, [1, 0])) + b_h.tensor
+                            )                            
+                            
+                            ops.append(tfl.FullyConnectedOperator([t, w_i, b_i], [input_mm]))                            
+                            ops.append(tfl.FullyConnectedOperator([t, w_h, b_h], [hidden_mm]))
 
-                        if i != 0 or compute_h:
+                            left_in = np.split(input_mm.tensor, 3, axis=1)
+                            dim_tensor = self.create_attr_tensor(np.array([1], dtype='int32'))
+                            splited_left_in = [self.create_transform_tensor(t) for t in left_in]
+                            
+                            ops.append(tfl.SplitOperator([dim_tensor, input_mm], splited_left_in, 3))
 
-                            hidden_mm_list = []
-                            for j, (w_r, b_r) in enumerate(zip(w_r_list, b_r_list)):
+                            right_in = np.split(hidden_mm.tensor, 3, axis=-1)
+                            splited_right_in = [self.create_transform_tensor(t) for t in right_in]
+                            
+                            ops.append(tfl.SplitOperator([dim_tensor, hidden_mm], splited_right_in, 3))
+                            
+                            rgate_left_in, zgate_left_in, ngate_left_in =  splited_left_in
+                            rgate_right_in, zgate_right_in, ngate_right_in_b =  splited_right_in
 
-                                hidden_mm = self.create_transform_tensor(
-                                    np.matmul(h.tensor, np.transpose(w_r.tensor, [1, 0])) + b_r.tensor
-                                )
-                                ops.append(tfl.FullyConnectedOperator([h, w_r, b_r], [hidden_mm]))
-                                hidden_mm_list.append(hidden_mm)
+                            rgate_in = self.create_transform_tensor(rgate_left_in.tensor + rgate_right_in.tensor)
+                            ops.append(tfl.AddOperator([rgate_left_in, rgate_right_in], [rgate_in]))
+                            
+                            rgate_out = self.create_transform_tensor(
+                                torch.sigmoid(torch.from_numpy(rgate_in.tensor)).numpy()
+                            )
+                            ops.append(tfl.LogisticOperator([rgate_in], [rgate_out]))
+                            
+                            zgate_in = self.create_transform_tensor(zgate_left_in.tensor + zgate_right_in.tensor)
+                            ops.append(tfl.AddOperator([zgate_left_in, zgate_right_in], [zgate_in]))
+                            
+                            zgate_out = self.create_transform_tensor(
+                                torch.sigmoid(torch.from_numpy(zgate_in.tensor)).numpy()
+                            )
+                            ops.append(tfl.LogisticOperator([zgate_in], [zgate_out]))
+
+                            ngate_right_in = self.create_transform_tensor(rgate_out.tensor * ngate_right_in_b.tensor)
+                            ops.append(tfl.MulOperator([rgate_out, ngate_right_in_b], [ngate_right_in]))
+
+                            ngate_in = self.create_transform_tensor(ngate_left_in.tensor + ngate_right_in.tensor)
+                            ops.append(tfl.AddOperator([ngate_left_in, ngate_right_in], [ngate_in]))
+
+                            ngate_out = self.create_transform_tensor(torch.tanh(torch.from_numpy(ngate_in.tensor)).numpy())
+                            ops.append(tfl.TanhOperator([ngate_in], [ngate_out]))
+
+                            constant_tensor = self.create_attr_tensor(torch.tensor(1, dtype=torch.float32))
+
+                            h_left_0 = self.create_transform_tensor(constant_tensor.tensor - zgate_out.tensor)
+                            ops.append(tfl.SubOperator([constant_tensor, zgate_out], [h_left_0]))
+
+                            h_left = self.create_transform_tensor(h_left_0.tensor * ngate_out.tensor)
+                            ops.append(tfl.MulOperator([h_left_0, ngate_out], [h_left]))
+
+                            if i != 0 or compute_h:
+                                h_right = self.create_transform_tensor(zgate_out.tensor * h.tensor)
+                                ops.append(tfl.MulOperator([zgate_out, h], [h_right]))
+
+                                h = self.create_transform_tensor(h_left.tensor + h_right.tensor)
+                                ops.append(tfl.AddOperator([h_left, h_right], [h]))
+
+                            elif i == 0 and not compute_h:
+                                h = h_left
+
+                            stacked_hs.append(h)
+                     
                         else:
-                            hidden_mm_list = b_r_list
+                            for j, (w_i, b_i) in enumerate(zip(w_i_list, b_i_list)):
 
-                        # calculate r,z,n gates
-                        rgate_in = self.create_transform_tensor(input_mm_list[0].tensor + hidden_mm_list[0].tensor)
-                        ops.append(tfl.AddOperator([input_mm_list[0], hidden_mm_list[0]], [rgate_in]))
+                                input_mm = self.create_transform_tensor(
+                                    np.matmul(t.tensor, np.transpose(w_i.tensor, [1, 0])) + b_i.tensor
+                                )
+                                ops.append(tfl.FullyConnectedOperator([t, w_i, b_i], [input_mm]))
+                                input_mm_list.append(input_mm)
 
-                        zgate_in = self.create_transform_tensor(input_mm_list[1].tensor + hidden_mm_list[1].tensor)
-                        ops.append(tfl.AddOperator([input_mm_list[1], hidden_mm_list[1]], [zgate_in]))
+                            if i != 0 or compute_h:
 
-                        zgate_out = self.create_transform_tensor(
-                            torch.sigmoid(torch.from_numpy(zgate_in.tensor)).numpy()
-                        )
+                                hidden_mm_list = []
+                                for j, (w_r, b_r) in enumerate(zip(w_r_list, b_r_list)):
 
-                        ops.append(tfl.LogisticOperator([zgate_in], [zgate_out]))
+                                    hidden_mm = self.create_transform_tensor(
+                                        np.matmul(h.tensor, np.transpose(w_r.tensor, [1, 0])) + b_r.tensor
+                                    )
+                                    ops.append(tfl.FullyConnectedOperator([h, w_r, b_r], [hidden_mm]))
+                                    hidden_mm_list.append(hidden_mm)
+                            else:
+                                hidden_mm_list = b_r_list
 
-                        rgate_out = self.create_transform_tensor(
-                            torch.sigmoid(torch.from_numpy(rgate_in.tensor)).numpy()
-                        )
-                        ops.append(tfl.LogisticOperator([rgate_in], [rgate_out]))
+                            # calculate r,z,n gates
+                            rgate_in = self.create_transform_tensor(input_mm_list[0].tensor + hidden_mm_list[0].tensor)
+                            ops.append(tfl.AddOperator([input_mm_list[0], hidden_mm_list[0]], [rgate_in]))
 
-                        ngate_in_hside = self.create_transform_tensor(rgate_out.tensor * hidden_mm_list[2].tensor)
-                        ops.append(tfl.MulOperator([rgate_out, hidden_mm_list[2]], [ngate_in_hside]))
+                            zgate_in = self.create_transform_tensor(input_mm_list[1].tensor + hidden_mm_list[1].tensor)
+                            ops.append(tfl.AddOperator([input_mm_list[1], hidden_mm_list[1]], [zgate_in]))
 
-                        ngate_in = self.create_transform_tensor(input_mm_list[2].tensor + ngate_in_hside.tensor)
-                        ops.append(tfl.AddOperator([input_mm_list[2], ngate_in_hside], [ngate_in]))
+                            zgate_out = self.create_transform_tensor(
+                                torch.sigmoid(torch.from_numpy(zgate_in.tensor)).numpy()
+                            )
+                            ops.append(tfl.LogisticOperator([zgate_in], [zgate_out]))
 
-                        ngate_out = self.create_transform_tensor(torch.tanh(torch.from_numpy(ngate_in.tensor)).numpy())
-                        ops.append(tfl.TanhOperator([ngate_in], [ngate_out]))
+                            rgate_out = self.create_transform_tensor(
+                                torch.sigmoid(torch.from_numpy(rgate_in.tensor)).numpy()
+                            )
+                            ops.append(tfl.LogisticOperator([rgate_in], [rgate_out]))
 
-                        constant_tensor = self.create_attr_tensor(torch.tensor(1, dtype=torch.float32))
+                            ngate_in_hside = self.create_transform_tensor(rgate_out.tensor * hidden_mm_list[2].tensor)
+                            ops.append(tfl.MulOperator([rgate_out, hidden_mm_list[2]], [ngate_in_hside]))
 
-                        h_left_0 = self.create_transform_tensor(constant_tensor.tensor - zgate_out.tensor)
-                        ops.append(tfl.SubOperator([constant_tensor, zgate_out], [h_left_0]))
+                            ngate_in = self.create_transform_tensor(input_mm_list[2].tensor + ngate_in_hside.tensor)
+                            ops.append(tfl.AddOperator([input_mm_list[2], ngate_in_hside], [ngate_in]))
 
-                        h_left = self.create_transform_tensor(h_left_0.tensor * ngate_out.tensor)
-                        ops.append(tfl.MulOperator([h_left_0, ngate_out], [h_left]))
+                            ngate_out = self.create_transform_tensor(torch.tanh(torch.from_numpy(ngate_in.tensor)).numpy())
+                            ops.append(tfl.TanhOperator([ngate_in], [ngate_out]))
 
-                        if i != 0 or compute_h:
-                            h_right = self.create_transform_tensor(zgate_out.tensor * h.tensor)
-                            ops.append(tfl.MulOperator([zgate_out, h], [h_right]))
+                            constant_tensor = self.create_attr_tensor(torch.tensor(1, dtype=torch.float32))
 
-                            h = self.create_transform_tensor(h_left.tensor + h_right.tensor)
-                            ops.append(tfl.AddOperator([h_left, h_right], [h]))
+                            h_left_0 = self.create_transform_tensor(constant_tensor.tensor - zgate_out.tensor)
+                            ops.append(tfl.SubOperator([constant_tensor, zgate_out], [h_left_0]))
 
-                        elif i == 0 and not compute_h:
-                            h = h_left
+                            h_left = self.create_transform_tensor(h_left_0.tensor * ngate_out.tensor)
+                            ops.append(tfl.MulOperator([h_left_0, ngate_out], [h_left]))
 
-                        stacked_hs.append(h)
+                            if i != 0 or compute_h:
+                                h_right = self.create_transform_tensor(zgate_out.tensor * h.tensor)
+                                ops.append(tfl.MulOperator([zgate_out, h], [h_right]))
+
+                                h = self.create_transform_tensor(h_left.tensor + h_right.tensor)
+                                ops.append(tfl.AddOperator([h_left, h_right], [h]))
+
+                            elif i == 0 and not compute_h:
+                                h = h_left
+
+                            stacked_hs.append(h)
 
                     tf_out_state_tensors[0].append(h)
                     output_ts.extend(stacked_hs[::stride])


### PR DESCRIPTION
Some duplicate codes can be removed. But the most serious thing is to find out why all pytests failed with hints below:

`AssertionError: The values for attribute 'shape' do not match: torch.Size([9, 1, 20]) != torch.Size([9, 0, 20]).`

i.e. You can run python converter_op_test.py -k test_gru_no_bias

Generated TFLite looks fine and Help wanted!